### PR TITLE
Add config file support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+config.js

--- a/AutoRTI.gs
+++ b/AutoRTI.gs
@@ -1,5 +1,11 @@
 function doPost(e) {
-  var ss = SpreadsheetApp.openById('PASTE_YOUR_SPREADSHEET_ID_HERE');
+  // Read the spreadsheet ID from script properties
+  var props = PropertiesService.getScriptProperties();
+  var spreadsheetId = props.getProperty('SPREADSHEET_ID');
+  if (!spreadsheetId) {
+    throw new Error('Missing SPREADSHEET_ID script property');
+  }
+  var ss = SpreadsheetApp.openById(spreadsheetId);
   var data;
   try {
     data = JSON.parse(e.postData.contents);

--- a/README.md
+++ b/README.md
@@ -1,2 +1,30 @@
 # AutoRTI
-repository for Auto RTI materials
+Repository for Auto RTI materials
+
+## Configuration
+
+Create a `config.js` file in the project root that defines your Google Spreadsheet ID and the published Web App URL used by the application. An example file is provided as `config.example.js`:
+
+```javascript
+window.AutoRTI_CONFIG = {
+  SPREADSHEET_ID: 'PASTE_SPREADSHEET_ID_HERE',
+  WEB_APP_URL: 'PASTE_WEB_APP_URL_HERE'
+};
+```
+
+You can copy the example and fill in your details:
+
+```bash
+cp config.example.js config.js
+# edit config.js and replace the placeholders
+```
+
+Alternatively, if the variables `SPREADSHEET_ID` and `WEB_APP_URL` are defined in your environment you can generate the file with:
+
+```bash
+envsubst < config.example.js > config.js
+```
+
+Make sure `config.js` is hosted alongside `index.html`.
+
+In your Apps Script project, set a script property named `SPREADSHEET_ID` to the same value so that `AutoRTI.gs` can open the correct spreadsheet.

--- a/config.example.js
+++ b/config.example.js
@@ -1,0 +1,6 @@
+window.AutoRTI_CONFIG = {
+  // Google Spreadsheet ID used by AutoRTI.gs
+  SPREADSHEET_ID: 'PASTE_SPREADSHEET_ID_HERE',
+  // Web App URL of the published Google Apps Script
+  WEB_APP_URL: 'PASTE_WEB_APP_URL_HERE'
+};

--- a/index.html
+++ b/index.html
@@ -147,6 +147,7 @@
       }
     }
   </style>
+  <script src="config.js"></script>
 </head>
 <body class="d-flex flex-column h-100">
   <!-- Splash Page Overlay -->
@@ -434,7 +435,7 @@
     /***********************************
      * Global Variables & Google Sheets URL
      ***********************************/
-    const GOOGLE_SHEETS_WEB_APP_URL = 'https://script.google.com/macros/s/AKfycbweOLW-hytrrV7QO4d1blVf_vxvuoIKZc2zKvqDKXzMT4r14Kk7-UxcHGOsMRUvlyTgyQ/exec';
+    const GOOGLE_SHEETS_WEB_APP_URL = window.AutoRTI_CONFIG.WEB_APP_URL;
     document.getElementById('webAppId').textContent += GOOGLE_SHEETS_WEB_APP_URL;
     
     // Gameplay Data Structures – always start with an empty nameList


### PR DESCRIPTION
## Summary
- rename HTML and script files to `index.html` and `AutoRTI.gs`
- add `config.example.js` and ignore `config.js`
- update README with configuration instructions
- load Web App URL from `config.js` in `index.html`
- read the spreadsheet ID from script properties in `AutoRTI.gs`

## Testing
- `npm test` *(fails: Could not read package.json)*
- `pytest` *(fails: command not found)*