### PR TITLE
Fix roster sending format

### DIFF
--- a/AutoRTI App Script
+++ b/AutoRTI App Script
@@ -6,6 +6,16 @@ function doPost(e) {
   } catch (err) {
     data = e.parameter;
   }
+  // Parse any nested JSON strings
+  for (var key in data) {
+    if (typeof data[key] === 'string') {
+      try {
+        data[key] = JSON.parse(data[key]);
+      } catch (err) {
+        // leave value as is if parsing fails
+      }
+    }
+  }
   
   // Get tab name, username, and fields
   var sheetName = data.sheetName || "Misc";

--- a/HTML
+++ b/HTML
@@ -1382,7 +1382,8 @@
         rosters[rosterName] = [...nameList];
         currentRosterName = rosterName;
         updateRosterOptions();
-        sendToGoogleSheets({ rosterName, roster: rosters[rosterName] });
+        // Send roster as JSON string for proper parsing on the server
+        sendToGoogleSheets({ rosterName, roster: JSON.stringify(rosters[rosterName]) });
         displaySuccessMessage('Roster saved successfully');
         saveToLocalStorage();
         logEvent(`Roster saved: ${rosterName}`);


### PR DESCRIPTION
## Summary
- send roster data as a JSON string from the HTML page
- support nested JSON strings in Apps Script so rosters are parsed correctly

## Testing
- `npm test` *(fails: could not find package.json)*