### PR TITLE
Remove webAppId from production HTML

### DIFF
--- a/HTML
+++ b/HTML
@@ -126,10 +126,6 @@
     .scoreboard-container {
       display: none;
     }
-    /* Hide the Google Sheets URL */
-    .webAppId {
-      color: transparent;
-    }
     /* Print-friendly CSS */
     @media print {
       nav, .nav-select, .utility-buttons, .btn, .modal, select, input[type="date"], input[type="number"] {
@@ -260,7 +256,6 @@
           </div>
         </div>
       </div>
-      <div class="webAppId" id="webAppId">Google Sheets Web App URL: </div>
     </div>
     <!-- End Gameplay Section -->
 
@@ -435,7 +430,13 @@
      * Global Variables & Google Sheets URL
      ***********************************/
     const GOOGLE_SHEETS_WEB_APP_URL = 'https://script.google.com/macros/s/AKfycbweOLW-hytrrV7QO4d1blVf_vxvuoIKZc2zKvqDKXzMT4r14Kk7-UxcHGOsMRUvlyTgyQ/exec';
-    document.getElementById('webAppId').textContent += GOOGLE_SHEETS_WEB_APP_URL;
+    const DEBUG_MODE = false;
+    if (DEBUG_MODE) {
+      const debugDiv = document.createElement('div');
+      debugDiv.id = 'webAppId';
+      debugDiv.textContent = `Google Sheets Web App URL: ${GOOGLE_SHEETS_WEB_APP_URL}`;
+      document.body.appendChild(debugDiv);
+    }
     
     // Gameplay Data Structures – always start with an empty nameList
     const nameList = [];


### PR DESCRIPTION
## Summary
- stop rendering the `webAppId` container by default
- only inject that container in debug mode via script

## Testing
- `npm test` *(fails: could not read package.json)*