### PR TITLE
Add sheet metadata to Sheet logging

### DIFF
--- a/AutoRTI App Script
+++ b/AutoRTI App Script
@@ -26,13 +26,25 @@ function doPost(e) {
       sheet.appendRow(headers);
       sheet.getRange(1,1,1,headers.length).setBackground("#DDEEFF").setFontWeight("bold");
     }
+    // Expand header row for any new keys not yet present
+    var existingHeader = sheet.getRange(1,1,1,sheet.getLastColumn()).getValues()[0];
+    var newKeys = [];
+    for (var key in data) {
+      if (key === "sheetName" || key === "username") continue;
+      if (existingHeader.indexOf(key) === -1) newKeys.push(key);
+    }
+    if (newKeys.length > 0) {
+      sheet.getRange(1, existingHeader.length + 1, 1, newKeys.length).setValues([newKeys]);
+      sheet.getRange(1,1,1,existingHeader.length + newKeys.length).setBackground("#DDEEFF").setFontWeight("bold");
+      existingHeader = existingHeader.concat(newKeys);
+    }
   } catch (e) {
     return ContentService.createTextOutput(JSON.stringify({result:"sheet error"}))
       .setMimeType(ContentService.MimeType.JSON);
   }
 
   // Build the row: Username, Timestamp, [all fields in header order]
-  var header = sheet.getDataRange().getValues()[0];
+  var header = sheet.getRange(1,1,1,sheet.getLastColumn()).getValues()[0];
   var row = [username, now];
   for (var i = 2; i < header.length; i++) {
     row.push(data[header[i]] || "");

--- a/HTML
+++ b/HTML
@@ -449,6 +449,7 @@
     let pauseHeatmapChart = null;   // Bubble plot for pause duration heatmap
     // Global variable for tracking the currently loaded roster name
     let currentRosterName = "";
+    let currentUserName = "";
     // Global variable for game start time (set when the game starts)
     let gameStartTime = null;
     // Global variable for the current VI schedule (in minutes)
@@ -513,6 +514,8 @@
       }
     }
     async function sendToGoogleSheets(data) {
+      data.sheetName = currentRosterName || "Misc";
+      data.username = currentUserName || "Anonymous";
       try {
         console.log('Sending data to Google Sheets:', data);
         const response = await fetch(GOOGLE_SHEETS_WEB_APP_URL, {
@@ -820,7 +823,6 @@
         timerData[index].startTime = new Date(timerData[index].startTime.getTime() + timerData[index].viInterval * 1000);
         sendToGoogleSheets({
           name: nameList[index].name,
-          timestamp: new Date().toLocaleString(),
           points: timerData[index].points,
           isPaused: timerData[index].isPaused,
           reason: timerData[index].pauseReason
@@ -867,7 +869,6 @@
         }
         sendToGoogleSheets({
           name: nameList[index].name,
-          timestamp: new Date().toLocaleString(),
           points: timerData[index].points,
           isPaused: timerData[index].isPaused,
           reason: timerData[index].pauseReason
@@ -914,7 +915,6 @@
       if (bonusSound.readyState >= 2) { bonusSound.currentTime = 0; bonusSound.play(); }
       sendToGoogleSheets({
         name: nameList[index].name,
-        timestamp: new Date().toLocaleString(),
         points: timerData[index].points,
         isPaused: timerData[index].isPaused,
         reason: timerData[index].pauseReason


### PR DESCRIPTION
## Summary
- capture current roster name and user when logging to sheets
- remove client timestamp field and rely on server timestamp
- auto-expand header row on the Apps Script server if new fields appear

## Testing
- `npm test` *(fails: package.json missing)*