### PR TITLE
Add basic .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,14 @@
+# Dependency directories
+node_modules/
+
+# Logs
+logs/
+*.log
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+
+# OS-specific files
+.DS_Store
+Thumbs.db
+Desktop.ini


### PR DESCRIPTION
## Summary
- add an initial `.gitignore` to filter out dependency folders, log files, and OS-specific artifacts

## Testing
- `npm test` *(fails: jest not found)*